### PR TITLE
Proposed changes for the mass-production bootloader

### DIFF
--- a/Caterina.c
+++ b/Caterina.c
@@ -81,7 +81,7 @@ uint16_t bootKey = 0x7777;
 volatile uint16_t *const bootKeyPtr = (volatile uint16_t *)0x0800;
 
 void StartSketch(void) {
-//    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
     cli();
 
     /* Undo TIMER1 setup and clear the count before running the sketch */

--- a/Caterina.c
+++ b/Caterina.c
@@ -56,7 +56,6 @@ static uint32_t CurrAddress;
  *  via a watchdog reset. When cleared the bootloader will exit, starting the watchdog and entering an infinite
  *  loop until the AVR restarts and the application runs.
  */
-static bool RunBootloader = true;
 
 
 #define ATTINY_I2C_ADDR 0xB0
@@ -194,14 +193,11 @@ int main(void) {
 
     Timeout = 0;
 
-    while (RunBootloader) {
+        /* Time out and start the sketch if one is present */
+    while (Timeout < TIMEOUT_PERIOD) {
     	update_progress();
         CDC_Task();
         USB_USBTask();
-        /* Time out and start the sketch if one is present */
-        if (Timeout > TIMEOUT_PERIOD)
-            RunBootloader = false;
-
     }
 
     /* Disconnect from the host - USB interface will be reset later along with the AVR */

--- a/Caterina.c
+++ b/Caterina.c
@@ -305,9 +305,9 @@ void EVENT_USB_Device_ControlRequest(void) {
 
 #if !defined(NO_BLOCK_SUPPORT)
 /** Reads or writes a block of EEPROM or FLASH memory to or from the appropriate CDC data endpoint, depending
- *  on the AVR910 protocol command issued.
+ *  on the AVR109 protocol command issued.
  *
- *  \param[in] Command  Single character AVR910 protocol command indicating what memory operation to perform
+ *  \param[in] Command  Single character AVR109 protocol command indicating what memory operation to perform
  */
 static void ReadWriteMemoryBlock(const uint8_t Command) {
     uint16_t BlockSize;
@@ -469,7 +469,7 @@ static void WriteNextResponseByte(const uint8_t Response) {
 #define STK_READ_PAGE       0x74  // 't'
 #define STK_READ_SIGN       0x75  // 'u'
 
-/** Task to read in AVR910 commands from the CDC data OUT endpoint, process them, perform the required actions
+/** Task to read in AVR109 commands from the CDC data OUT endpoint, process them, perform the required actions
  *  and send the appropriate response back to the host.
  */
 void CDC_Task(void) {

--- a/Caterina.c
+++ b/Caterina.c
@@ -127,7 +127,6 @@ void CheckReprogrammingKey(void) {
             StartSketch();
         }
     }
-    _delay_ms(5);
     PORTC |= _BV(6); // Turn the ATTiny back on
 }
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -120,7 +120,7 @@ void CheckReprogrammingKey(void) {
     // before the ATTiny had fully get reset
     _delay_ms(5);
     if ( PINF & _BV(1)) { // If the pin is hot
-        _delay_ms(5); // debounce
+        _delay_ms(10); // debounce
         if (PINF & _BV(1)) { // If it's still hot, no key was pressed
             // Start the sketch
             DDRC &= ~_BV(6); // Turn the ATTiny back on

--- a/Caterina.c
+++ b/Caterina.c
@@ -142,7 +142,6 @@ static inline void EnableLEDs(void) {
     PORTC |= _BV(7);
 
     i2c_init();
-//    i2c_send( ATTINY_I2C_ADDR, &run_leds_fast[0], sizeof(run_leds_fast));
 }
 
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -131,8 +131,8 @@ static inline void CheckReprogrammingKey(void) {
 }
 
 
-static inline void update_progress(void) {
     i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+static inline void UpdateProgressLED(void) {
     // We bitshift the LED counter by 3 to slow it down a bit
     uint8_t led_cmd[] = { UPDATE_LED_CMD, progress_led>>3, RED };
     if (progress_led >= 256) {
@@ -212,7 +212,7 @@ int main(void) {
 
         /* Time out and start the sketch if one is present */
     while (Timeout < TIMEOUT_PERIOD) {
-    	update_progress();
+        UpdateProgressLED();
         CDC_Task();
         USB_USBTask();
     }
@@ -501,7 +501,8 @@ void CDC_Task(void) {
 
     /* Read in the bootloader command (first byte sent from host) */
     uint8_t Command = FetchNextCommandByte();
-
+    
+    UpdateProgressLED();
     progress_led++;
 
     if (Command == 'E') {

--- a/Caterina.c
+++ b/Caterina.c
@@ -159,6 +159,8 @@ int main(void) {
     /* Watchdog may be configured with a 15 ms period so must disable it before going any further */
     wdt_disable();
 
+    /* Don't run the user application if the reset vector is blank (no app loaded) */
+    bool ApplicationValid = (pgm_read_word_near(0) != 0xFFFF);
 
 
     if (mcusr_state & (1<<PORF)) {

--- a/Caterina.c
+++ b/Caterina.c
@@ -182,7 +182,7 @@ int main(void) {
         // External reset -  we should continue to self-programming mode.
     } else { // If it's not an external reset, it must be a triggered reset. So
         // Let's make sure the user is holding down the magic key.
-        // Otherwise, it's pretty easy to blow bad firmware onto the
+        // Otherwise, it's pretty easy to blow malicious firmware onto the
         // device.
         CheckReprogrammingKey();
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -168,9 +168,9 @@ int main(void) {
     wdt_disable();
 
     i2c_init();
+
     // Set the LEDs to black, so they don't flash.
     TurnLEDsOff();
-    EnableLEDs();
 
 
     /* Don't run the user application if the reset vector is blank (no app loaded) */
@@ -208,7 +208,9 @@ int main(void) {
 
     Timeout = 0;
 
-        /* Time out and start the sketch if one is present */
+    EnableLEDs();
+
+    /* Time out and start the sketch if one is present */
     while (Timeout < TIMEOUT_PERIOD) {
         UpdateProgressLED();
         CDC_Task();

--- a/Caterina.c
+++ b/Caterina.c
@@ -132,7 +132,7 @@ void update_progress(void) {
     i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
     // We bitshift the LED counter by 3 to slow it down a bit
     uint8_t led_cmd[] = { UPDATE_LED_CMD, progress_led>>3, RED };
-    if (progress_led++ >= 256) {
+    if (progress_led >= 256) {
         progress_led = 0;
     }
     i2c_send(ATTINY_I2C_ADDR, &led_cmd[0], sizeof(led_cmd));
@@ -144,7 +144,6 @@ inline void EnableLEDs(void) {
     PORTC |= _BV(7);
 
     i2c_init();
-    update_progress();
 //    i2c_send( ATTINY_I2C_ADDR, &run_leds_fast[0], sizeof(run_leds_fast));
 }
 
@@ -196,6 +195,7 @@ int main(void) {
     Timeout = 0;
 
     while (RunBootloader) {
+    	update_progress();
         CDC_Task();
         USB_USBTask();
         /* Time out and start the sketch if one is present */
@@ -487,7 +487,7 @@ void CDC_Task(void) {
     /* Read in the bootloader command (first byte sent from host) */
     uint8_t Command = FetchNextCommandByte();
 
-    update_progress();
+    progress_led++;
 
     if (Command == 'E') {
         /* We nearly run out the bootloader timeout clock,
@@ -641,7 +641,6 @@ void CDC_Task(void) {
         WriteNextResponseByte('?');
     }
 
-    update_progress();
 
 
     /* Select the IN endpoint */

--- a/Caterina.c
+++ b/Caterina.c
@@ -74,7 +74,7 @@ static uint8_t progress_led = 24; // This is the LED on the "prog" key
 
 
 /* Bootloader timeout timer */
-#define TIMEOUT_PERIOD	8000
+#define TIMEOUT_PERIOD 32767	
 uint16_t Timeout = 0;
 
 uint16_t bootKey = 0x7777;

--- a/Caterina.c
+++ b/Caterina.c
@@ -99,7 +99,7 @@ void StartSketch(void) {
 }
 
 
-void CheckReprogrammingKey(void) {
+static inline void CheckReprogrammingKey(void) {
 
     // Hold the ATTiny in reset, so it can't mess with this read
     DDRC |= _BV(6);

--- a/Caterina.c
+++ b/Caterina.c
@@ -136,7 +136,7 @@ void update_progress(void) {
     i2c_send(ATTINY_I2C_ADDR, &led_cmd[0], sizeof(led_cmd));
 }
 
-inline void EnableLEDs(void) {
+static inline void EnableLEDs(void) {
     // Turn on power to the LED net
     DDRC |= _BV(7);
     PORTC |= _BV(7);

--- a/Caterina.c
+++ b/Caterina.c
@@ -168,8 +168,11 @@ int main(void) {
     // Set the LEDs to black, so they don't flash.
 
 
+    if (mcusr_state & (1<<PORF)) {
+        CheckReprogrammingKey();
 
-    if (( ((mcusr_state & (1<<WDRF)) && bootKeyPtrVal != bootKey )) // or an accidental watchdog reset
+    }
+    else if (((mcusr_state & (1<<WDRF)) && bootKeyPtrVal != bootKey ) // or an accidental watchdog reset
             && (pgm_read_word(0) != 0xFFFF)) {
         // After a power-on reset skip the bootloader and jump straight to sketch
         // if one exists.

--- a/Caterina.c
+++ b/Caterina.c
@@ -140,8 +140,6 @@ static inline void EnableLEDs(void) {
     // Turn on power to the LED net
     DDRC |= _BV(7);
     PORTC |= _BV(7);
-
-    i2c_init();
 }
 
 
@@ -183,6 +181,12 @@ int main(void) {
         CheckReprogrammingKey();
 
     }
+    }
+    // Set the LEDs to black, so they don't flash.
+    i2c_init();
+    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+    EnableLEDs();
+    
     /* Setup hardware required for the bootloader */
     SetupHardware();
 
@@ -234,7 +238,6 @@ void SetupHardware(void) {
     TIMSK1 = (1 << OCIE1A);					// enable timer 1 output compare A match interrupt
     TCCR1B = ((1 << CS11) | (1 << CS10));	// 1/64 prescaler on timer 1 input
 
-    EnableLEDs();
 
     /* Initialize USB Subsystem */
     USB_Init();

--- a/Caterina.c
+++ b/Caterina.c
@@ -200,7 +200,6 @@ int main(void) {
         }
     }
 
-    
     /* Setup hardware required for the bootloader */
     SetupHardware();
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -81,6 +81,7 @@ uint16_t bootKey = 0x7777;
 volatile uint16_t *const bootKeyPtr = (volatile uint16_t *)0x0800;
 
 void StartSketch(void) {
+    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
     cli();
 
     /* Undo TIMER1 setup and clear the count before running the sketch */

--- a/Caterina.c
+++ b/Caterina.c
@@ -81,7 +81,7 @@ uint16_t bootKey = 0x7777;
 volatile uint16_t *const bootKeyPtr = (volatile uint16_t *)0x0800;
 
 void StartSketch(void) {
-    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+//    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
     cli();
 
     /* Undo TIMER1 setup and clear the count before running the sketch */

--- a/Caterina.c
+++ b/Caterina.c
@@ -147,6 +147,10 @@ static inline void EnableLEDs(void) {
     PORTC |= _BV(7);
 }
 
+static inline void TurnLEDsOff(void) {
+    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+
+}
 
 
 /** Main program entry point. This routine configures the hardware required by the bootloader, then continuously
@@ -164,9 +168,9 @@ int main(void) {
     /* Watchdog may be configured with a 15 ms period so must disable it before going any further */
     wdt_disable();
 
-    // Set the LEDs to black, so they don't flash.
     i2c_init();
-    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+    // Set the LEDs to black, so they don't flash.
+    TurnLEDsOff();
     EnableLEDs();
 
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -123,12 +123,12 @@ void CheckReprogrammingKey(void) {
         _delay_ms(10); // debounce
         if (PINF & _BV(1)) { // If it's still hot, no key was pressed
             // Start the sketch
-            DDRC &= ~_BV(6); // Turn the ATTiny back on
+            PORTC |= _BV(6); // Turn the ATTiny back on
             StartSketch();
         }
     }
     _delay_ms(5);
-    DDRC &= ~_BV(6); // Turn the ATTiny back on
+    PORTC |= _BV(6); // Turn the ATTiny back on
 }
 
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -198,6 +198,9 @@ int main(void) {
         CDC_Task();
         USB_USBTask();
     }
+    
+    /* Wait a short time to end all USB transactions and then disconnect */
+    _delay_us(1000);
 
     /* Disconnect from the host - USB interface will be reset later along with the AVR */
     USB_Detach();

--- a/Caterina.c
+++ b/Caterina.c
@@ -164,6 +164,11 @@ int main(void) {
     /* Watchdog may be configured with a 15 ms period so must disable it before going any further */
     wdt_disable();
 
+    // Set the LEDs to black, so they don't flash.
+    i2c_init();
+    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
+    EnableLEDs();
+
 
     /* Don't run the user application if the reset vector is blank (no app loaded) */
     bool ApplicationValid = (pgm_read_word_near(0) != 0xFFFF);
@@ -191,11 +196,6 @@ int main(void) {
             CheckReprogrammingKey();
         }
     }
-
-    // Set the LEDs to black, so they don't flash.
-    i2c_init();
-    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
-    EnableLEDs();
 
     
     /* Setup hardware required for the bootloader */

--- a/Caterina.c
+++ b/Caterina.c
@@ -80,7 +80,6 @@ uint16_t bootKey = 0x7777;
 volatile uint16_t *const bootKeyPtr = (volatile uint16_t *)0x0800;
 
 void StartSketch(void) {
-    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
     cli();
 
     /* Undo TIMER1 setup and clear the count before running the sketch */

--- a/Caterina.c
+++ b/Caterina.c
@@ -180,25 +180,26 @@ int main(void) {
         if (((mcusr_state & (1<<WDRF)) && bootKeyPtrVal != bootKey )) {
             // If it looks like an "accidental" watchdog reset then start the sketch.
             StartSketch();
-   	} else if (mcusr_state == _BV(EXTRF)) {
-        	// External reset -  we should continue to self-programming mode.
-		// Note that we're checking that mcusr_state is set ONLY to external reset
-		// The atmega32u4 will populate EXTRF on power on as well as an explicit 
-		// external reset condition
-		// If htis logic were "mcusr_state & _BV(EXTRF)", it would trigger on
-		// first boot...sometimes.
-		// That'd lead to the keyboard going into a lengthy bootloader phase
-		// when the user plugged it in
-		// We explicitly don't want to trigger this in the case of a watchdog reset,
-		// power on reset or a brownout reset.
-        } else { 
-	    // If it's not an external reset, it must be a triggered reset. So
+        } else if (mcusr_state == _BV(EXTRF)) {
+            // External reset -  we should continue to self-programming mode.
+            // Note that we're checking that mcusr_state is set ONLY to external reset
+            // The atmega32u4 will populate EXTRF on power on as well as an explicit
+            // external reset condition
+            // If htis logic were "mcusr_state & _BV(EXTRF)", it would trigger on
+            // first boot...sometimes.
+            // That'd lead to the keyboard going into a lengthy bootloader phase
+            // when the user plugged it in
+            // We explicitly don't want to trigger this in the case of a watchdog reset,
+            // power on reset or a brownout reset.
+        } else {
+            // If it's not an external reset, it must be a triggered reset. So
             // Let's make sure the user is holding down the magic key.
             // Otherwise, it's pretty easy to blow malicious firmware onto the
             // device.
             CheckReprogrammingKey();
         }
     }
+
 
     /* Setup hardware required for the bootloader */
     SetupHardware();
@@ -216,7 +217,7 @@ int main(void) {
         CDC_Task();
         USB_USBTask();
     }
-    
+
     /* Wait a short time to end all USB transactions and then disconnect */
     _delay_us(1000);
 
@@ -501,7 +502,7 @@ void CDC_Task(void) {
 
     /* Read in the bootloader command (first byte sent from host) */
     uint8_t Command = FetchNextCommandByte();
-    
+
     TurnLEDsOff();
     UpdateProgressLED();
     progress_led++;

--- a/Caterina.c
+++ b/Caterina.c
@@ -69,7 +69,7 @@ static uint8_t make_leds_black[] = {0x03,0x00,0x00,0x00};
 // static uint8_t make_leds_red[] = {UPDATE_LED_CMD,0x03,RED };
 // static uint8_t run_leds_fast[] = { 0x06, 0x05};
 
-static uint8_t progress_led = 24; // This is the LED on the "prog" key
+static uint8_t progress_led = 24; // This is the LED on the "prog" key, bitshifted by 3 bits
 
 
 /* Bootloader timeout timer */

--- a/Caterina.c
+++ b/Caterina.c
@@ -146,7 +146,7 @@ static inline void EnableLEDs(void) {
     PORTC |= _BV(7);
 }
 
-static inline void TurnLEDsOff(void) {
+__attribute__ ((noinline)) static void TurnLEDsOff(void) {
     i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
 
 }

--- a/Caterina.c
+++ b/Caterina.c
@@ -112,7 +112,13 @@ void CheckReprogrammingKey(void) {
     PORTF |= _BV(1); // turn on pullup
     PORTF &= ~_BV(0); // make our output low
 
-    __asm__("nop"); // Just in case we need a moment to get the read, like on the ATTiny
+    // we need a moment to get the read, or we get some real weird behavior
+    // specifically, at random intervals, we end up in the bootloader on first boot
+    // even if the prog key isn't held down.
+    //
+    // I (jesse) believe that the issue is that we were getting our reads
+    // before the ATTiny had fully get reset
+    _delay_ms(5);
     if ( PINF & _BV(1)) { // If the pin is hot
         _delay_ms(5); // debounce
         if (PINF & _BV(1)) { // If it's still hot, no key was pressed

--- a/Caterina.c
+++ b/Caterina.c
@@ -131,7 +131,7 @@ void CheckReprogrammingKey(void) {
 }
 
 
-void update_progress(void) {
+static inline void update_progress(void) {
     i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
     // We bitshift the LED counter by 3 to slow it down a bit
     uint8_t led_cmd[] = { UPDATE_LED_CMD, progress_led>>3, RED };

--- a/Caterina.c
+++ b/Caterina.c
@@ -169,8 +169,7 @@ int main(void) {
 
 
 
-    if (((mcusr_state & (1<<PORF))  // After power on reset
-            || ((mcusr_state & (1<<WDRF)) && bootKeyPtrVal != bootKey )) // or an accidental watchdog reset
+    if (( ((mcusr_state & (1<<WDRF)) && bootKeyPtrVal != bootKey )) // or an accidental watchdog reset
             && (pgm_read_word(0) != 0xFFFF)) {
         // After a power-on reset skip the bootloader and jump straight to sketch
         // if one exists.

--- a/Caterina.c
+++ b/Caterina.c
@@ -131,7 +131,6 @@ static inline void CheckReprogrammingKey(void) {
 }
 
 
-    i2c_send( ATTINY_I2C_ADDR, &make_leds_black[0], sizeof(make_leds_black));
 static inline void UpdateProgressLED(void) {
     // We bitshift the LED counter by 3 to slow it down a bit
     uint8_t led_cmd[] = { UPDATE_LED_CMD, progress_led>>3, RED };
@@ -502,6 +501,7 @@ void CDC_Task(void) {
     /* Read in the bootloader command (first byte sent from host) */
     uint8_t Command = FetchNextCommandByte();
     
+    TurnLEDsOff();
     UpdateProgressLED();
     progress_led++;
 

--- a/Caterina.c
+++ b/Caterina.c
@@ -138,7 +138,7 @@ void update_progress(void) {
     i2c_send(ATTINY_I2C_ADDR, &led_cmd[0], sizeof(led_cmd));
 }
 
-void EnableLEDs(void) {
+inline void EnableLEDs(void) {
     // Turn on power to the LED net
     DDRC |= _BV(7);
     PORTC |= _BV(7);

--- a/Caterina.c
+++ b/Caterina.c
@@ -159,7 +159,6 @@ int main(void) {
     /* Watchdog may be configured with a 15 ms period so must disable it before going any further */
     wdt_disable();
 
-    // Set the LEDs to black, so they don't flash.
 
 
     if (mcusr_state & (1<<PORF)) {

--- a/Caterina.c
+++ b/Caterina.c
@@ -73,7 +73,7 @@ static uint8_t progress_led = 24; // This is the LED on the "prog" key, bitshift
 
 
 /* Bootloader timeout timer */
-#define TIMEOUT_PERIOD 32767	
+#define TIMEOUT_PERIOD 8000
 uint16_t Timeout = 0;
 
 uint16_t bootKey = 0x7777;

--- a/i2c.c
+++ b/i2c.c
@@ -36,7 +36,7 @@ uint8_t i2c_send( uint8_t address, uint8_t *data, uint8_t length ) {
     // Send data bytes minus the last one. Expect ACK.
     const uint8_t * bufferPtr = data;
     if (!error) {
-        for (uint16_t i = (length-1); i >0 ; --i) {
+        for (uint8_t i = (length-1); i >0 ; --i) {
             error = i2c_send_one(*bufferPtr,TWI_TXDATA_ACKED);
             if (!error) {
                 ++bufferPtr;

--- a/i2c.c
+++ b/i2c.c
@@ -20,7 +20,7 @@ inline uint8_t i2c_send_one (uint8_t data, uint8_t response) {
     return (TWSR != response);
 }
 
-uint8_t i2c_send( uint8_t address, uint8_t *data, uint8_t length ) {
+void i2c_send( uint8_t address, uint8_t *data, uint8_t length ) {
     uint8_t error = 0;
     _delay_ms(1);
     // START condition.
@@ -48,7 +48,7 @@ uint8_t i2c_send( uint8_t address, uint8_t *data, uint8_t length ) {
 
     // Send last data byte.
     if (!error) {
-        error = i2c_send_one(*bufferPtr,TWI_TXDATA_NACKED);
+        i2c_send_one(*bufferPtr,TWI_TXDATA_NACKED);
     }
 
     // If there was an error, abort the communication
@@ -56,5 +56,4 @@ uint8_t i2c_send( uint8_t address, uint8_t *data, uint8_t length ) {
     // Both of thse are the same signal
     TWCR = _BV(TWSTO) | _BV(TWINT) | _BV(TWEN);
 
-    return (!error);
 }

--- a/i2c.h
+++ b/i2c.h
@@ -3,5 +3,5 @@
 #include <stdint.h>
 
 void i2c_init(void);
-uint8_t i2c_send( uint8_t address, uint8_t * data, uint8_t length );
+void i2c_send( uint8_t address, uint8_t * data, uint8_t length );
 


### PR DESCRIPTION
The main thing we're doing here is letting the keyboard enter the bootloader when the Prog key is held down at boot.

While doing this, we found some really weird behavior that could cause the keyboard to enter bootloader mode if the prog key _wasn't_ held down.

Along the way, we imported some modernizations from Lufa's CDC bootloader and found some memory savings.

We also did some work to try to limit the "color flash" from the LEDs on first connect. Sad to say, we're not 100% there on that one.